### PR TITLE
do not use lsof or netstat/ss if not needed

### DIFF
--- a/bin/pgup.sh
+++ b/bin/pgup.sh
@@ -189,21 +189,32 @@ done
 }
 
 find_datadir_of_running_proc() {
-local d
-for d in $($LSOF -p $1 2> /dev/null | grep DIR | awk '{print $9}'); do
-  [[ -f $d/global/pg_control ]] && echo $d
-done
+  local pid
+  pid=$1
+  if [[ -h /proc/${pid}/cwd && -f /proc/${pid}/cwd/global/pg_control ]]; then
+    readlink -f /proc/${ppid}/cwd
+  else
+    local d
+    for d in $($LSOF -p $1 2> /dev/null | grep DIR | awk '{print $9}'); do
+      [[ -f $d/global/pg_control ]] && echo $d
+    done
+  fi
 }
 
 
 find_port_of_running_proc() {
    local pid=$1
-   which netstat > /dev/null 2>&1
-   local RC=$?
-   if [[ $RC -eq 0 ]]; then
-     netstat -ltnp 2>/dev/null| grep -E "^tcp .* ${pid}" | awk '{print $4}' | cut -d":" -f2
+   if [[ -h /proc/${pid}/cwd && -f /proc/${pid}/cwd/postmaster.pid ]]; then
+     #using the port from pid
+     head -4 /proc/${pid}/cwd/postmaster.pid |tail -1
    else
-     ss -ltnp | grep "pid=${pid}," | awk '{print $4}' | cut -d":" -f2
+     which netstat > /dev/null 2>&1
+     local RC=$?
+     if [[ $RC -eq 0 ]]; then
+       netstat -ltnp 2>/dev/null| grep -E "^tcp .* ${pid}" | awk '{print $4}' | cut -d":" -f2
+     else
+       ss -ltnp | grep "pid=${pid}," | awk '{print $4}' | cut -d":" -f2
+     fi
    fi
 }
 

--- a/bin/pgup.sh
+++ b/bin/pgup.sh
@@ -192,7 +192,7 @@ find_datadir_of_running_proc() {
   local pid
   pid=$1
   if [[ -h /proc/${pid}/cwd && -f /proc/${pid}/cwd/global/pg_control ]]; then
-    readlink -f /proc/${ppid}/cwd
+    readlink -f /proc/${pid}/cwd
   else
     local d
     for d in $($LSOF -p $1 2> /dev/null | grep DIR | awk '{print $9}'); do


### PR DESCRIPTION
The resource consumption of lsof/netstat/ss could be quite significant a lots of clusters and pids it could be one of the top commands, if you are using pgoperate and the daemon (which checks the state of the postgres).

some thought about this change:
- lsof needs quite some resource (cpu) in environments with lot's of cluster lsof could be one of the top command. therefore using current working dir (cwd) from the pg-process is much more efficient. But if one time cwd is not anymore the data dir from pg, the fallback with lsof should still work.
- I'm unsure about this comment "Check lsof location. Required for remote execution." Line 25 what is meant. Any ideas? And does this change also work?
- same for find port as postmaster.pid does have this information already, why searching with ss/netstat? Here we do not have a fallback if the order is changed (at least there aren't lot's of changes https://github.com/postgres/postgres/blame/master/src/include/utils/pidfile.h) there could be some low level checks /proc/net/tcp to pid/fds
