### PR TITLE
Exclude more directories from automatic scan

### DIFF
--- a/bin/install_pgbasenv.sh
+++ b/bin/install_pgbasenv.sh
@@ -25,8 +25,8 @@
 
 # Defaults
 TVDBASE_DEF=$HOME/tvdtoolbox
-PGBASENV_EXCLUDE_DIRS_DEF="tmp proc sys"
-PGBASENV_EXCLUDE_FILESYSTEMS_DEF="nfs tmpfs"
+PGBASENV_EXCLUDE_DIRS_DEF="bin boot dev etc lib lib32 lib64 proc root run sbin sys tmp usr"
+PGBASENV_EXCLUDE_FILESYSTEMS_DEF="autofs nfs nfs4 ramfs tmpfs"
 PGBASENV_SEARCH_MAXDEPTH_DEF=7
 PGBASENV_INITIAL_ALIAS_DEF=
 

--- a/bin/pgbasenv.sh
+++ b/bin/pgbasenv.sh
@@ -31,8 +31,8 @@ declare -r VERSION=$(cat $SCRIPTDIR/VERSION)
 owner=$(id -un)
 declare -r LSOF=$([[ ! -f /bin/lsof ]] && which lsof || echo "lsof")
 
-PGBASENV_EXCLUDE_DIRS_DEF="tmp proc sys"
-PGBASENV_EXCLUDE_FILESYSTEMS_DEF="nfs tmpfs"
+PGBASENV_EXCLUDE_DIRS_DEF="bin boot dev etc lib lib32 lib64 proc root run sbin sys tmp usr"
+PGBASENV_EXCLUDE_FILESYSTEMS_DEF="autofs nfs nfs4 ramfs tmpfs"
 PGBASENV_SEARCH_MAXDEPTH_DEF=7
 PGBASENV_SEARCH_TIMEOUT_DEF=5
 


### PR DESCRIPTION
On modern systems, the list of places where a database should not be is even longer than it ever was: special purpose directories, the operating system environment and other installation paths. Also, there are more filesystems that should not be touched: autofs (as we do not want to trigger random automounts here), ramfs (which can pop up in various places) and nfs4 (nfs is already excluded).